### PR TITLE
Attempt to integrate card deck with card order

### DIFF
--- a/FutureVersion/CardSystem/examples/basicOrderExample.js
+++ b/FutureVersion/CardSystem/examples/basicOrderExample.js
@@ -1,7 +1,10 @@
 const { randomRangeInteger } = require("../randomLogic");
 const { startTurn } = require("../../DayCounterLogic");
-const { Card, getDeckEffects, addToTopOfDeck } = require("../index");
+const { Card, getPlayedDeckEffects, getDeckEffects, addToTopOfDeck, drawFromTopOfDeck } = require("../index");
 const { MakePlayerOrdersFromOrderDeck } = require("../examples/common");
+const { shuffleDrawPlay} = require("../examples/espionageOrder.js")
+const { EspionageDeck } = require("../examples/espionageEffectExample.js")
+
 const {
   AskForPlayerResponse,
   ParseResponseToOrders,
@@ -26,6 +29,16 @@ const orderDeck = [
       return { manPower: randomRangeInteger(0, 500) };
     },
   }),
+  new Card({
+    //Espionage
+    name: "Espionage",
+    description: "Espionage Order",
+    playCard: (state) => {
+      //calculations with state can be done here
+        const espionageResult = shuffleDrawPlay(EspionageDeck);
+        return espionageResult; 
+    },
+  }),
 ];
 
 const playerDecks = {
@@ -44,11 +57,18 @@ startTurn(0, (turnNumber) => {
     MakePlayerOrdersFromOrderDeck(orderDeck);
 
   // Log the result of the order
+  if (orderFromResponse !== "Espionage"){
   console.log(
     `General you ordered us to ${orderFromResponse} and as a result we ${
       Math.sign(ordersPlayedEffects.manPower) > 0 ? "gained" : "lost"
     } ${ordersPlayedEffects.manPower} men`
-  );
+  )};
+
+  if (orderFromResponse === "Espionage"){
+    console.log(
+      'General you ordered us to Espionage'
+    )
+  };
 
   // Log the current effects of the resource deck
   console.log(getDeckEffects(playerDecks.resourceDeck));

--- a/FutureVersion/CardSystem/examples/espionageEffectExample.js
+++ b/FutureVersion/CardSystem/examples/espionageEffectExample.js
@@ -9,12 +9,12 @@ const orderDeck = [
     name: "Attack",
     description: "Attack Order",
     playCard: (state) => {
-      const esponiageManpowerModifier =
-        state.espionageLevel === undefined ? 0 : state.esponiageLevel;
+      const espionageManpowerModifier =
+        state.espionageLevel === undefined ? 0 : state.espionageLevel;
       //calculations with state can be done here
       return {
         manPower: randomRangeInteger(-5000, -1000),
-        esponiageManpowerModifier,
+        espionageManpowerModifier,
       };
     },
   }),
@@ -28,18 +28,20 @@ const orderDeck = [
     },
   }),
   new Card({
-    name: "Espoinage",
+    name: "Espionage",
     description: "gather intel and find weakness",
-    playCard: (state) => {},
+    playCard: (state) => {
+        
+    },
   }),
 ];
 
 const EspionageDeck = [
   new Card({
-    name: "increase espoinage level",
-    description: "increase espoinage levels for both modifer and other bonuses",
+    name: "increase espionage level",
+    description: "increase espionage levels for both modifer and other bonuses",
     effect: {
-      esponiage: 1,
+      espionage: 1,
     },
   }),
   new Card({
@@ -51,10 +53,18 @@ const EspionageDeck = [
   }),
   ...DuplicateCard(
     new Card({
-      name: "no espoinage bonus",
+      name: "no espionage bonus",
       description: "no bonus",
     }),
     5
+  ),
+  ...DuplicateCard(
+    new Card({
+      name: "Test",
+      description: "no bonus",
+      effect: console.log("WALALALA")
+    }),
+    299
   ),
 ];
 
@@ -71,3 +81,7 @@ startTurn(0, (turnNumber) => {
   //     } ${ordersPlayedEffects.manPower} men`
   //   );
 });
+
+module.exports = {
+  EspionageDeck
+};

--- a/FutureVersion/CardSystem/examples/espionageOrder.js
+++ b/FutureVersion/CardSystem/examples/espionageOrder.js
@@ -1,0 +1,21 @@
+const { Card, deckEffectsToString, getDeckEffects, getPlayedDeckEffects, drawFromTopOfDeck, shuffleDeck} = require("../index");
+
+
+const shuffleDrawPlay = (deck, state) => {
+    const shuffledDeck = shuffleDeck(deck);
+    const drawncard = drawFromTopOfDeck(shuffledDeck, 1);
+    const playCardEffect = getPlayedDeckEffects(drawncard);
+
+    // const playerDecks = {shuffledDeck: []}
+    // const deckEffect = deckEffectsToString(playerDecks.shuffledDeck)
+    // const playDrawnCard = 
+    // const cardEffects = drawnCard.playCard(state);
+    // const deckEffectsString = deckEffectsToString(deck);
+  
+    return {playCardEffect};
+    
+  };
+
+ module.exports = {
+  shuffleDrawPlay
+ }

--- a/FutureVersion/CardSystem/examples/eventEffectExamples.js
+++ b/FutureVersion/CardSystem/examples/eventEffectExamples.js
@@ -5,6 +5,7 @@ const {
   DuplicateCard,
   Card,
 } = require("../index");
+const { randomRangeInteger } = require("../randomLogic");
 
 //this is a deck that shouldn't change, think of it as a blueprint for all cards and then when we start a game we make a copy of it
 const eventDeck = [
@@ -22,7 +23,7 @@ const eventDeck = [
   new Card({
     name: "Intervention",
     description: "A great power intervenes on your side",
-    effect: { manPower: 10000 },
+    effect: { morale: 1 },
   }),
   new Card({
     name: "Blockade",
@@ -34,6 +35,11 @@ const eventDeck = [
     name: "Pillar Of Fire",
     description: "A Pilar of fire destroys friend and foe alike",
     effect: { manPower: -10000, attackStrength: 1 },
+  }),
+  new Card({
+    name: "Torrential Rains",
+    description: "The heavens open up and drench land and men",
+    effect: { attritionModifier: 15, turnlength: randomRangeInteger(1, 4) }
   }),
   ...DuplicateCard(
     new Card({
@@ -82,3 +88,4 @@ console.log(`current effects ${deckEffectsToString(playerDecks.eventDeck)}`);
 
 //get players effect deck which should have one card in it
 console.log(playerDecks.eventDeck);
+

--- a/Version1/Algorithm.js
+++ b/Version1/Algorithm.js
@@ -12,4 +12,13 @@
 . we want to update the user about their armies status
     - manpower counter
 
+
+4. create an army variable where we can store multiple states of the army.  
+    - always have an overall manpower pool, but also divide the manpower into various states "in camp", "building/projects", attack, foraging 
+
+5. as the options for a player increase, expand gameplay for player and allow player to make more than one order per turn to include various actions as well
+
+6. Revamp mechanics for attacking and capturing city
+    - build an dynamic and interconnected system for defense and offense that interacts with each other. 
+
 */


### PR DESCRIPTION
Created "espionage" card order in basicorderexample.  Tried to link it with "espionage deck".  created a function that would shuffle, draw, and play card effects once player chooses espionage.  function is exported from espionageOrder.js file.  Some unintended effects happened. 

Added 200x cards with the effect: console.log("WALALA").  The card is suppose to be picked after espionage order and then display the text in terminal, 
When running basicorderexample, somehow the text is displayed already without any order being inputted.  